### PR TITLE
Make TMUX open panes in current directory

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -4,9 +4,11 @@
 ############## NAVIGATION ##############
 ########################################
 
-# split panes using | and - kill using 0
-bind = split-window -h
-bind - split-window -v
+# split panes using - and = (+) and open to current path
+bind = split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+
+# Kill panes using the "0" key
 bind-key 0 kill-pane
 
 unbind '"'


### PR DESCRIPTION
This commit changes tmux to have new panes be the current directory instead of where tmux was opened. This was an issue as every time I needed a new window the directories were usually "far apart". This distance required me to change what I was currently thinking of to locate the current directory I was modifying.