### PR TITLE
Fix resize bug

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -22,6 +22,9 @@ bind-key [ select-pane -t -1
 # Avoids confirmation when killing a window
 bind-key & kill-window
 
+# Add scrolling by default
+set -g mouse on
+
 
 ########################################
 ############### COMMANDS ###############
@@ -33,7 +36,7 @@ set -sg escape-time 1
 
 
 # Emulate Vim's copy mode
-bind Escape copy-mode
+#bind Escape copy-mode
 unbind p
 bind p paste-buffer
 bind -T copy-mode-vi 'v' send-keys -X begin-selection
@@ -45,6 +48,15 @@ bind -T copy-mode-vi 'y' send-keys -X copy-selection
 ############### DISPLAY ################
 ########################################
 
+unbind Left
+unbind Down
+unbind Up
+unbind Right
+
+bind Up resize-pane -U 5
+bind Down resize-pane -D 5
+bind Right resize-pane -R 10
+bind Left resize-pane -L 10
 
 set -g default-terminal "screen-256color"
 


### PR DESCRIPTION
When using [ and ] to swap current pane the switch broke the ability to resize panes. I have brought back that functionality with this change